### PR TITLE
Typo fix

### DIFF
--- a/content/modules/ROOT/pages/adoption/modules/proc_retrieving-topology-specific-service-configuration.adoc
+++ b/content/modules/ROOT/pages/adoption/modules/proc_retrieving-topology-specific-service-configuration.adoc
@@ -223,7 +223,7 @@ After the {OpenStackShort} control plane services are shut down, if any of the e
 +
 [source,bash,role=execute,subs=attributes]
 ----
-cat >~/.source_cloud_exported_variables <<\EOF
+cat >~/.source_cloud_exported_variables << EOF
 PULL_OPENSTACK_CONFIGURATION_DATABASES="$PULL_OPENSTACK_CONFIGURATION_DATABASES"
 PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK="$PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK"
 PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS="$PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS"


### PR DESCRIPTION
The \ before EOF prevents the target file from getting the right content as variables are not evaluated:
```
[lab-user@bastion files]$ cat >~/.source_cloud_exported_variables <<\EOF
PULL_OPENSTACK_CONFIGURATION_DATABASES="$PULL_OPENSTACK_CONFIGURATION_DATABASES"
PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK="$PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK"
PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS="$PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS"
PULL_OPENSTACK_CONFIGURATION_NOVA_COMPUTE_HOSTNAMES="$PULL_OPENSTACK_CONFIGURATION_NOVA_COMPUTE_HOSTNAMES" 
PULL_OPENSTACK_CONFIGURATION_NOVAMANAGE_CELL_MAPPINGS="$PULL_OPENSTACK_CONFIGURATION_NOVAMANAGE_CELL_MAPPINGS"
SRIOV_AGENTS="$SRIOV_AGENTS"
EOF
[lab-user@bastion files]$ 
[lab-user@bastion files]$ cat ~/.source_cloud_exported_variables 
PULL_OPENSTACK_CONFIGURATION_DATABASES="$PULL_OPENSTACK_CONFIGURATION_DATABASES"
PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK="$PULL_OPENSTACK_CONFIGURATION_MYSQLCHECK_NOK"
PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS="$PULL_OPENSTACK_CONFIGURATION_NOVADB_MAPPED_CELLS"
PULL_OPENSTACK_CONFIGURATION_NOVA_COMPUTE_HOSTNAMES="$PULL_OPENSTACK_CONFIGURATION_NOVA_COMPUTE_HOSTNAMES"
PULL_OPENSTACK_CONFIGURATION_NOVAMANAGE_CELL_MAPPINGS="$PULL_OPENSTACK_CONFIGURATION_NOVAMANAGE_CELL_MAPPINGS"
SRIOV_AGENTS="$SRIOV_AGENTS"
[lab-user@bastion files]$ 
```