### PR TITLE
Fixed path to glance images in nfsserver

### DIFF
--- a/content/modules/ROOT/pages/adoption/modules/proc_adopting-image-service-with-nfs-backend.adoc
+++ b/content/modules/ROOT/pages/adoption/modules/proc_adopting-image-service-with-nfs-backend.adoc
@@ -152,10 +152,10 @@ sh-5.1openstack image list
 [source,bash,role=execute,subs=attributes]
 ----
 
-* On the `nfs-server` node, the same `uuid` is in the exported `/var/nfs`:
+* On the `nfs-server` node, the same `uuid` is in the exported `/nfs/glance`:
 +
 [source,bash,role=execute,subs=attributes]
 ----
-ls /var/nfs/
+ls /nfs/glance/
 634482ca-4002-4a6d-b1d5-64502ad02630
 ----


### PR DESCRIPTION
Fixed path to the glance images in the nfsserver:
```
[root@nfsserver ~]# ll /nfs/glance/
total 20928
-rw-r-----. 1 42415 42415 21430272 May 30 04:31 dfb99d7b-ee50-4112-89d0-a72f25735c59
[root@nfsserver ~]# 
[root@nfsserver ~]# ls /nfs/glance/
dfb99d7b-ee50-4112-89d0-a72f25735c59
[root@nfsserver ~]# 
```