### PR TITLE
fix(secret): Add openstack namespace to subscription-manager secret

### DIFF
--- a/content/modules/ROOT/pages/common/create-dp.adoc
+++ b/content/modules/ROOT/pages/common/create-dp.adoc
@@ -63,7 +63,7 @@ Add your username and password
 [source,bash,role=execute]
 ----
 oc create secret generic subscription-manager \
---from-literal rhc_auth='{"login": {"username": "your_username", "password": "your_password"}}'
+--from-literal rhc_auth='{"login": {"username": "your_username", "password": "your_password"}}' -n openstack
 ----
 
 Create a secret for the subscription manager and a secret for the Red Hat registry:


### PR DESCRIPTION
The oc command used to generate the subscription manager secret should include the openstack namespace.

Without it, the OpenstackDataPlaneNodeSets return the following error because the secret is created in the default namespace:

```
DataPlaneNodeSet error occurred Unable to generate inventory for openstack-edpm-compute-1
``` 

More info at the following Red Hat KB article:

https://access.redhat.com/solutions/7127411