### PR TITLE
Add some clarification on user/pwd use and floating ip

### DIFF
--- a/content/modules/ROOT/pages/common/access.adoc
+++ b/content/modules/ROOT/pages/common/access.adoc
@@ -118,6 +118,10 @@ openstack floating ip create public --floating-ip-addres 172.21.0.205
 
 Add the floating IP above to the new VM in the next step.
 
+[IMPORTANT]
+
+If you get an error saying the IP `172.21.0.205` is in use, replace it with the next one (eg. 172.21.0.206) in the `openstack` commands above and below and the `ssh` right after it.
+
 [source,bash,role=execute]
 ----
 openstack server add floating ip test-server 172.21.0.205

--- a/content/modules/ROOT/pages/common/create-dp.adoc
+++ b/content/modules/ROOT/pages/common/create-dp.adoc
@@ -53,11 +53,11 @@ ssh-keygen -f ./id -t ecdsa-sha2-nistp521 -N ''
 oc create secret generic nova-migration-ssh-key --from-file=ssh-privatekey=id --from-file=ssh-publickey=id.pub -n openstack -o yaml | oc apply -f-
 ----
 
-Create a secret for the subscription manager and a secret for the Red Hat registry:
+Create a secret for the subscription manager:
 
 [IMPORTANT]
 
-Add your username and password
+Add your username and password from the https://www.redhat.com/wapps/ugc/protected/password.html[Red Hat Customer Portal]
 
 [source,bash,role=execute]
 ----
@@ -65,11 +65,11 @@ oc create secret generic subscription-manager \
 --from-literal rhc_auth='{"login": {"username": "your_username", "password": "your_password"}}' -n openstack
 ----
 
-Create a secret for the subscription manager and a secret for the Red Hat registry:
+Create a secret for the Red Hat registry:
 
 [IMPORTANT]
 
-Add your username and password
+Add your service account username and password (token) generated as described in https://access.redhat.com/articles/RegistryAuthentication#creating-registry-service-accounts-6[Registry Service Accounts]
 
 [source,bash,role=execute]
 ----


### PR DESCRIPTION
Updated docs to add clarifications on username and password for subscription-manager and registry. Also a note about a possible error when assigning a floating IP to a VM.