### PR TITLE
Adding missing step in adoption process

### DIFF
--- a/content/modules/ROOT/pages/adoption/network-isolation.adoc
+++ b/content/modules/ROOT/pages/adoption/network-isolation.adoc
@@ -30,6 +30,15 @@ Replace the UUID to the GUID of your environment:
 find . -type f -exec sed -i 's/UUID/{guid}/g' {} +
 ----
 
+Replace the IPs of the worker nodes by the variables from the lab:
+
+[source,bash,role=execute,subs=attributes]
+----
+sed -i 's/EXTERNAL_IP_WORKER_1/{rhoso_external_ip_worker_1}/' osp-ng-nncp-w1.yaml
+sed -i 's/EXTERNAL_IP_WORKER_2/{rhoso_external_ip_worker_2}/' osp-ng-nncp-w2.yaml
+sed -i 's/EXTERNAL_IP_WORKER_3/{rhoso_external_ip_worker_3}/' osp-ng-nncp-w3.yaml
+----
+
 Apply preconfigured yamls indivdually:
 
 [source,bash,role=execute]


### PR DESCRIPTION
The commands to replace the external IP placeholders with the actual IP addresses from the lab environment are present in the deployment doc, but missing in the adoption.